### PR TITLE
Removed limitations on updates of dependent pods.

### DIFF
--- a/PromiseKit-AFNetworking.podspec
+++ b/PromiseKit-AFNetworking.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
   
-  s.dependency 'AFNetworking', '~>2.0.0'
-  s.dependency 'PromiseKit/Promise', '~> 0.9.13'
+  s.dependency 'AFNetworking', '~> 2.0'
+  s.dependency 'PromiseKit/Promise', '~> 0.9'
     
 end


### PR DESCRIPTION
Following the request in #3, this commit removes limitations on versions of required pods. Now only changes on MAJOR version (e.g. 2.0.0 -> 3.0.0) are not allowed. 
