### PR TITLE
Dont autoupgrade to PromiseKit 2

### DIFF
--- a/PromiseKit-AFNetworking.podspec
+++ b/PromiseKit-AFNetworking.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   
   s.dependency 'AFNetworking', '~> 2.0'
-  s.dependency 'PromiseKit/Promise'
+  s.dependency 'PromiseKit/Promise', '~> 1.5'
   s.dependency 'PromiseKit/When'
     
 end


### PR DESCRIPTION
Without this modifier when PromiseKit 2 is released your users will auto upgrade, which may not be desired. Probably you will want that eventually, but you should choice when it happens.