### PR TITLE
Bump PromiseKit/CorePromise

### DIFF
--- a/PromiseKit-AFNetworking.podspec
+++ b/PromiseKit-AFNetworking.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   
   s.dependency 'AFNetworking', '~> 3.1.0'
-  s.dependency 'PromiseKit/CorePromise', '~> 3.0'
-    
+  s.dependency 'PromiseKit/CorePromise', '~> 4.0'
+
 end


### PR DESCRIPTION
We couldn't get our project to work with Swift 3 because Swift 3 required at least PromiseKit/CorePromise 4.0. Updating the `.podspec` in this project to use the updated CorePromise version did not introduce any breaking changes and appears to still work well.
